### PR TITLE
Filing generic

### DIFF
--- a/WebApp/RikTest/Attributes/AppSetting.cs
+++ b/WebApp/RikTest/Attributes/AppSetting.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AppSetting : AttributeBase
+    {
+        
+    }
+}

--- a/WebApp/RikTest/Attributes/AppSettingJson.cs
+++ b/WebApp/RikTest/Attributes/AppSettingJson.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Linq;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class AppSettingJson : AttributeBase
+    {
+        public string[] Sections { get; }
+
+        public AppSettingJson(params string[] sections)
+        {
+            if (!sections?.Any() ?? true)
+            {
+                sections = new[] {"AppConfiguration"};
+            }
+            Sections = sections;
+        }
+    }
+
+}

--- a/WebApp/RikTest/Attributes/AttributeBase.cs
+++ b/WebApp/RikTest/Attributes/AttributeBase.cs
@@ -1,0 +1,7 @@
+﻿namespace WebApp.RikTest.Attributes
+{
+    public abstract class AttributeBase : System.Attribute
+    {
+        
+    }
+}

--- a/WebApp/RikTest/Attributes/ConnectionSetting.cs
+++ b/WebApp/RikTest/Attributes/ConnectionSetting.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ConnectionSetting : AttributeBase
+    {
+        
+    }
+}

--- a/WebApp/RikTest/Attributes/Factory.cs
+++ b/WebApp/RikTest/Attributes/Factory.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Interface)]
+    public sealed class Factory : AttributeBase
+    {
+    }
+}

--- a/WebApp/RikTest/Attributes/NoDefault.cs
+++ b/WebApp/RikTest/Attributes/NoDefault.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class NoDefault : AttributeBase
+    {
+    }
+}

--- a/WebApp/RikTest/Attributes/Singleton.cs
+++ b/WebApp/RikTest/Attributes/Singleton.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class Singleton : AttributeBase
+    {
+    }
+}

--- a/WebApp/RikTest/Attributes/Transient.cs
+++ b/WebApp/RikTest/Attributes/Transient.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace WebApp.RikTest.Attributes
+{
+    [NoDefault]
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class Transient : AttributeBase
+    {
+    }
+}

--- a/WebApp/RikTest/Extensions/ContainerExtensions.cs
+++ b/WebApp/RikTest/Extensions/ContainerExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using Castle.Windsor;
+using Castle.Windsor.Installer;
+
+namespace WebApp.RikTest.Extensions
+{
+    public static class ContainerExtensions
+    {
+        
+        public static bool DoesKernelNotAlreadyContainFacility<T>(IWindsorContainer container)
+        {
+            return container.Kernel.GetFacilities().ToList().FirstOrDefault(x => x.GetType() == typeof(T)) == null;
+        }
+
+        public static bool IsRegistered<T>(IWindsorContainer container )
+        {
+            return container.IsRegistered(typeof(T));
+        }
+        public static bool IsRegistered(this IWindsorContainer container, Type type)
+        {
+            if (type.IsAbstract || type.IsInterface)
+            {
+                return container.Kernel.HasComponent(type);
+            }
+            return false; //if no registrar, default to not registered
+        }
+
+        
+
+        public static void RunInstallers(this IWindsorContainer container, Assembly assembly = null)
+        {
+            if (assembly == null)
+            {
+                try
+                {
+                    assembly = Assembly.GetEntryAssembly();
+                }
+                catch
+                {
+                    // ignored
+                }
+            }
+            if (assembly == null)
+            {
+                assembly = Assembly.GetCallingAssembly();
+            }
+            container.Install(FromAssembly.InThisApplication(assembly));
+        }
+    }
+}

--- a/WebApp/RikTest/Extensions/FilterExtensions.cs
+++ b/WebApp/RikTest/Extensions/FilterExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Reflection;
+using Castle.MicroKernel.Registration;
+
+namespace WebApp.RikTest.Extensions
+{
+    public static class FilterExtensions
+    {
+        public static AssemblyFilter Net40FilterByName(Type type)
+        {
+            var typeNamespace = Assembly.GetEntryAssembly().GetName().Name?.Split('.').First();
+            if(string.IsNullOrWhiteSpace(typeNamespace)) throw new NullReferenceException("AssemblyFilter namespace cannot be null");
+            return new AssemblyFilter(".").FilterByName(an => an.Name.StartsWith(typeNamespace, true, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/WebApp/RikTest/Extensions/TypeExtensions.cs
+++ b/WebApp/RikTest/Extensions/TypeExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Castle.Windsor;
+using WebApp.RikTest.Attributes;
+
+#pragma warning disable 162
+
+
+namespace WebApp.RikTest.Extensions
+{
+    [SuppressMessage("ReSharper", "ConstantConditionalAccessQualifier")]
+    public static class TypeExtensions
+    {
+        public static bool IoCCommonFilter<T>(this Type type, IWindsorContainer container) where T : AttributeBase
+        {
+            return HasNotIoCNoDefaultAndIsNotRegistered(type, container) && HasAttribute<T>(type)
+                    && HasBaseOrInterface(type);
+        }
+
+        public static bool HasAttribute<T>(Type type) where T : AttributeBase
+        {
+#if NET40 || NET452 || NET471
+            return (bool) type.GetCustomAttributes(typeof(T), true)?.Any();
+#endif
+#if NETSTANDARD2 
+            return type.GetTypeInfo().GetCustomAttribute<T>(true) != null;
+#endif
+            return false;
+        }
+
+        public static bool HasBaseOrInterface(this Type type)
+        {
+            return type.BaseType != null || type.GetInterfaces().Any();
+        }
+
+        public static bool HasNotIoCNoDefaultAndIsNotRegistered(this Type type, IWindsorContainer container)
+        {
+            return !HasAttribute<NoDefault>(type) && !container.IsRegistered(type);
+        }
+
+        public static bool HasNoIocAttributeAndIsNotRegistered(this Type type, IWindsorContainer container)
+        {
+            return !HasAttribute<AttributeBase>(type) && !container.IsRegistered(type);
+        }
+
+        public static bool HasNoIoCAttributes(this Type type)
+        {
+            return !HasAttribute<NoDefault>(type);
+        }
+    }
+}

--- a/WebApp/RikTest/InstallerTransient.cs
+++ b/WebApp/RikTest/InstallerTransient.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using Castle.MicroKernel.Registration;
+using Castle.MicroKernel.SubSystems.Configuration;
+using Castle.Windsor;
+using WebApp.RikTest.Extensions;
+
+namespace WebApp.RikTest
+{
+    public class InstallerTransient : IWindsorInstaller
+    {
+        public void Install(IWindsorContainer container, IConfigurationStore store)
+        {
+            container.Register(Classes.FromAssemblyInThisApplication(Assembly.GetEntryAssembly())
+                .Where(t => t.HasNoIocAttributeAndIsNotRegistered(container)
+                            && t.HasNoIoCAttributes()
+                            && t.HasBaseOrInterface())
+                .WithServiceAllInterfaces()
+                .Configure(component =>
+                {
+                    component.IsFallback();
+                    component.Named($"{component.Implementation.FullName}-TransientAuto");
+                })
+                .WithServiceAllInterfaces()
+                .LifestyleTransient());
+        }
+    }
+}

--- a/WebApp/RikTest/Interfaces/IDbContext.cs
+++ b/WebApp/RikTest/Interfaces/IDbContext.cs
@@ -1,0 +1,7 @@
+﻿namespace WebApp.RikTest.Interfaces
+{
+    public interface IDbContext
+    {
+        
+    }
+}

--- a/WebApp/RikTest/Interfaces/ISeed.cs
+++ b/WebApp/RikTest/Interfaces/ISeed.cs
@@ -1,0 +1,7 @@
+﻿namespace WebApp.RikTest.Interfaces
+{
+    public interface ISeed<in T> where T : IDbContext
+    {
+        void Up(T db);
+    }
+}

--- a/WebApp/RikTest/Interfaces/ISeedInjection.cs
+++ b/WebApp/RikTest/Interfaces/ISeedInjection.cs
@@ -1,0 +1,7 @@
+﻿namespace WebApp.RikTest.Interfaces
+{
+    public interface ISeedInjection<T> where T : IDbContext
+    {
+        void Up();
+    }
+}

--- a/WebApp/RikTest/MyContext.cs
+++ b/WebApp/RikTest/MyContext.cs
@@ -1,0 +1,9 @@
+﻿using WebApp.RikTest.Interfaces;
+
+namespace WebApp.RikTest
+{
+    public class MyContext : IDbContext
+    {
+        
+    }
+}

--- a/WebApp/RikTest/SeedInjection.cs
+++ b/WebApp/RikTest/SeedInjection.cs
@@ -1,0 +1,18 @@
+﻿using WebApp.RikTest.Interfaces;
+
+namespace WebApp.RikTest
+{
+    public class SeedInjection<T> : ISeedInjection<T> where T : IDbContext
+    {
+        private readonly ISeed<IDbContext> _seed;
+
+        public SeedInjection(ISeed<IDbContext> seed)
+        {
+            _seed = seed;
+        }
+
+        public void Up( )
+        {
+        }
+    }
+}

--- a/WebApp/Startup.cs
+++ b/WebApp/Startup.cs
@@ -10,6 +10,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using WebApp.RikTest;
+using WebApp.RikTest.Extensions;
 
 namespace WebApp
 {
@@ -65,6 +67,8 @@ namespace WebApp
 					"default",
 					"{controller=Home}/{action=Index}/{id?}");
 			});
+
+            Container.RunInstallers();
 		}
 
 		private void RegisterApplicationComponents()


### PR DESCRIPTION
Hi @fir3pho3nixx 
Here is the failing example.
It is when i have a class with a generic and and an interface with the same generic.
Then ctor inject the interface with the generic resolved.
Castle can handel is no problem. But your resolver is not happy about it. specifically the HasMatchingGenericTypesWithoutArguments

within the FrameworkConfigurationDependencyResolver

Should the code not look more like this. i.e. it is only the serviceCollection itmes that should be checked :


![image](https://user-images.githubusercontent.com/2411563/38271619-37b66a04-3787-11e8-89f2-c38ac69aa179.png)


return serviceCollection.Any(x => x.ServiceType == dependencyType) && dependencyType.IsGenericType && HasMatchingGenericTypeDefinitions(dependencyType);